### PR TITLE
allow opening read-only romfs

### DIFF
--- a/Nindot/RomfsPathUtility.cs
+++ b/Nindot/RomfsPathUtility.cs
@@ -75,7 +75,7 @@ public static class RomfsPathUtility
         FileStream filestream;
         SHA256 mySHA256 = SHA256.Create();
 
-        filestream = new FileStream(filePath, FileMode.Open)
+        filestream = new FileStream(filePath, FileMode.Open, FileAccess.Read)
         {
             Position = 0
         };


### PR DESCRIPTION
my romfs is read-only so i wasn't able to select it on first boot due to the `FileStream` ctor without a `FileAccess` requiring write access by default. this should fix that